### PR TITLE
Add selection strategies for the main LaTeX file

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ The service accepts ZIP archives containing LaTeX files in its root and compiles
 passes are performed to ensure that all references are resolved. After eight passes, compilation is aborted and the log
 files are returned together with the PDF generated so far.
 
-*WIP* Currently the archive must contain exactly one `.tex` file, which is chosen as the main document.
-If more than one `.tex` file is present, the first one in the ZIP file listing is chosen.
+For LaTeX compilation, the file `main.tex` in the archive root is selected if it exists. If not, the first `.tex` file
+encountered during archive processing is chosen.
 Other files can be included as needed.
 
 The response is sent to the `replyTo` queue specified in the request message and contains a ZIP archive with the

--- a/src/main/java/com/penguineering/synctexng/synctexng_rmq_server/archive/FirstTexFileStrategy.java
+++ b/src/main/java/com/penguineering/synctexng/synctexng_rmq_server/archive/FirstTexFileStrategy.java
@@ -1,0 +1,23 @@
+package com.penguineering.synctexng.synctexng_rmq_server.archive;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+/**
+ * Strategy to determine the main LaTeX file from a set of files.
+ * This strategy chooses the first file that ends with ".tex".
+ */
+public class FirstTexFileStrategy implements MainLatexFileStrategy {
+    private Path rootTexFile = null;
+
+    @Override
+    public void acceptPath(Path path) {
+        if (Objects.isNull(rootTexFile) && path.toString().endsWith(".tex"))
+            rootTexFile = path;
+    }
+
+    @Override
+    public Path getChosenPath() {
+        return rootTexFile;
+    }
+}

--- a/src/main/java/com/penguineering/synctexng/synctexng_rmq_server/archive/LayeredMainFileStrategy.java
+++ b/src/main/java/com/penguineering/synctexng/synctexng_rmq_server/archive/LayeredMainFileStrategy.java
@@ -1,0 +1,31 @@
+package com.penguineering.synctexng.synctexng_rmq_server.archive;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Strategy to determine the main LaTeX file from a set of files.
+ * This strategy chooses the first result of the given strategies that is not null, in the order of the provided strategies.
+ */
+public class LayeredMainFileStrategy implements MainLatexFileStrategy {
+    private final List<MainLatexFileStrategy> strategies;
+
+    public LayeredMainFileStrategy(List<MainLatexFileStrategy> strategies) {
+        this.strategies = Objects.requireNonNull(strategies, "strategies must not be null");
+    }
+
+    @Override
+    public void acceptPath(Path path) {
+        strategies.forEach(strategy -> strategy.acceptPath(path));
+    }
+
+    @Override
+    public Path getChosenPath() {
+        return strategies.stream()
+                .map(MainLatexFileStrategy::getChosenPath)
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/src/main/java/com/penguineering/synctexng/synctexng_rmq_server/archive/MainLatexFileStrategy.java
+++ b/src/main/java/com/penguineering/synctexng/synctexng_rmq_server/archive/MainLatexFileStrategy.java
@@ -1,0 +1,22 @@
+package com.penguineering.synctexng.synctexng_rmq_server.archive;
+
+import java.nio.file.Path;
+
+/**
+ * Strategy to determine the main LaTeX file from a set of files.
+ */
+public interface MainLatexFileStrategy {
+    /**
+     * Accept a path to be considered for the main LaTeX file.
+     *
+     * @param paths the path to consider
+     */
+    void acceptPath(Path paths);
+
+    /**
+     * Get the chosen path.
+     *
+     * @return the chosen path
+     */
+    Path getChosenPath();
+}

--- a/src/main/java/com/penguineering/synctexng/synctexng_rmq_server/archive/NamedFileStrategy.java
+++ b/src/main/java/com/penguineering/synctexng/synctexng_rmq_server/archive/NamedFileStrategy.java
@@ -1,0 +1,28 @@
+package com.penguineering.synctexng.synctexng_rmq_server.archive;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+/**
+ * Strategy to determine the main LaTeX file from a set of files.
+ * This strategy chooses the file with the same name as the target file.
+ */
+public class NamedFileStrategy implements MainLatexFileStrategy {
+    private final Path targetPath;
+    private Path chosenPath = null;
+
+    public NamedFileStrategy(Path targetPath) {
+        this.targetPath = Objects.requireNonNull(targetPath, "targetPath must not be null");
+    }
+
+    @Override
+    public void acceptPath(Path path) {
+        if (path.getFileName().equals(targetPath.getFileName()))
+            chosenPath = path;
+    }
+
+    @Override
+    public Path getChosenPath() {
+        return chosenPath;
+    }
+}

--- a/src/main/java/com/penguineering/synctexng/synctexng_rmq_server/archive/RequestArchiveExtractor.java
+++ b/src/main/java/com/penguineering/synctexng/synctexng_rmq_server/archive/RequestArchiveExtractor.java
@@ -11,16 +11,18 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
+import java.util.function.Consumer;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
 @Getter
 public class RequestArchiveExtractor extends WorkDirSupplied {
-    private Path rootTexFile = null;
+    private final Consumer<Path> pathObserver;
 
-    public RequestArchiveExtractor(WorkDir workDir) {
+    public RequestArchiveExtractor(WorkDir workDir,
+                                   Consumer<Path> pathObserver) {
         super(workDir);
+        this.pathObserver = pathObserver;
     }
 
     public List<Path> unpack(byte[] data) throws IOException {
@@ -32,8 +34,8 @@ public class RequestArchiveExtractor extends WorkDirSupplied {
                 Path file = getWorkPath().resolve(zipEntry.getName());
                 files.add(file);
 
-                if (Objects.isNull(rootTexFile) && file.toString().endsWith(".tex"))
-                    rootTexFile = file;
+                Path relativeArchivePath = getWorkPath().relativize(file);
+                pathObserver.accept(relativeArchivePath);
 
                 Files.createDirectories(file.getParent());
                 Files.copy(zis, file);


### PR DESCRIPTION
This pull request introduces a new strategy pattern for determining the main LaTeX file from a set of files in a ZIP archive, along with refactoring and improving the LaTeX file selection logic. This is part of the solution for #3 .

### Improvements to LaTeX file selection:
* Updated the README to reflect the new logic for selecting the main LaTeX file, prioritizing `main.tex` if it exists.

### New strategy pattern implementation:
* Added `FirstTexFileStrategy` class to select the first `.tex` file encountered.
* Added `LayeredMainFileStrategy` class to combine multiple strategies and select the first valid result.
* Added `MainLatexFileStrategy` interface to define the contract for LaTeX file selection strategies.
* Added `NamedFileStrategy` class to select a file with a specific name, such as `main.tex`.

### Refactoring:
* Refactored `RequestArchiveExtractor` to use a `Consumer<Path>` for observing file paths and removed the old rootTexFile logic. [[1]](diffhunk://#diff-dec88e583368e87e75cf8dbe0633d90f53a93bc6242833c0583eacf70d5c0eacL14-R25) [[2]](diffhunk://#diff-dec88e583368e87e75cf8dbe0633d90f53a93bc6242833c0583eacf70d5c0eacL35-R38)
* Updated `TexGenerationRequestHandler` to use the new strategy pattern for determining the main LaTeX file. [[1]](diffhunk://#diff-6370e3333ef483b3a53323adc447a37a1c0c35336e475085b783b12fc845429bL4-R4) [[2]](diffhunk://#diff-6370e3333ef483b3a53323adc447a37a1c0c35336e475085b783b12fc845429bR124-R142)