### PR TITLE
Fix workflow caching

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -38,9 +38,9 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/.m2
-        key: ${{ runner.os }}-m2-${ github.ref }}-${{ hashFiles('**/pom.xml') }}
+        key: ${{ runner.os }}-m2-${{ github.ref }}-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
-          ${{ runner.os }}-m2-${ github.ref }}
+          ${{ runner.os }}-m2-${{ github.ref }}
           ${{ runner.os }}-m2-main
 
     - name: Run Maven Build

--- a/.github/workflows/maven-test.yml
+++ b/.github/workflows/maven-test.yml
@@ -25,9 +25,9 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/.m2
-        key: ${{ runner.os }}-m2-${ github.ref }}-${{ hashFiles('**/pom.xml') }}
+        key: ${{ runner.os }}-m2-${{ github.ref }}-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
-          ${{ runner.os }}-m2-${ github.ref }}
+          ${{ runner.os }}-m2-${{ github.ref }}
           ${{ runner.os }}-m2-main
 
     - name: Run tests


### PR DESCRIPTION
This pull request includes minor corrections to the syntax in two GitHub workflow files. The changes ensure that the `key` and `restore-keys` parameters use the correct syntax for GitHub Actions expressions.

Fixes to GitHub workflow files:

* [`.github/workflows/docker-build.yml`](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82L41-R43): Corrected the syntax for the `key` and `restore-keys` parameters in the `actions/cache` step.
* [`.github/workflows/maven-test.yml`](diffhunk://#diff-88d135787cea7a45f4de39326918279fe9ba0e4f9068b1dfda501c7e3db93c40L28-R30): Corrected the syntax for the `key` and `restore-keys` parameters in the `actions/cache` step.